### PR TITLE
Use custom check abs implementation for div_by_one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "psy-math"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "bytemuck",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psy-math"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 description = "A fork of jet-proto-math. Helpful math utilities, used by PsyLend."

--- a/src/number_128.rs
+++ b/src/number_128.rs
@@ -240,15 +240,14 @@ impl Neg for Number128 {
 /// as a right bit-shift (on absolute value) by 10, followed by a division by
 /// `9_765_625` (which is `5^10`), as this is faster than a division by `10_000_000_000`.
 /// The sign is then restored before returning the result.
-///
-/// Works for all i128 inputs except `i128::MIN`
 fn div_by_one(value: i128) -> i128 {
     // abs_result is expected to be positive unless
     // value.abs() has overflowed when value == i128::MIN
     let abs_result = (value.abs() >> 10) / (9_765_625_i128);
 
     // Return result with sign of value.
-    // For abs_result < 0, return result without sign bit change.
+    // For abs_result < 0, when value == i128::MIN, abs_result is the correct value
+    // without any sign change.
     if value > 0 || abs_result < 0 {
         abs_result
     } else {

--- a/src/number_128.rs
+++ b/src/number_128.rs
@@ -271,7 +271,7 @@ fn mul_by_one(value: i128) -> i128 {
     // 128 bits. This is a conservative estimate, so it may return false positives.
     // Note that checked_abs is not used here, since the overflow case would
     // be caught by the following check.
-    let left_bits = 128 -  value.abs().leading_zeros();
+    let left_bits = 128 - value.abs().leading_zeros();
     if (left_bits + ONE_REPR_BITS + 1) > 128 {
         panic!("Overflow in mul by one")
     }

--- a/src/number_128.rs
+++ b/src/number_128.rs
@@ -463,7 +463,7 @@ mod tests {
     #[test]
     fn test_fast_checked_failures() {
         // Test cases when fast_checked_mul detects false positives
-        //  and expects overflow, even when checked_mul does not.
+        // and expects overflow, even when checked_mul does not.
         let test_cases = [
             (i128::MAX, 1),
             (i128::MAX >> 1, 2),


### PR DESCRIPTION
i128 `abs` may overflow in the case when i128 is `i128::MIN`. Using `checked_abs` turned out to be computationally expensive (+50% in execution time). 

Instead, since `i128::MIN.checked_div(ONE).unwrap()` has the same value as `(i128::MIN.abs() >> 10) / (9_765_625_i128)`, we treat it `abs_result > 0` as a special case of the overflow and return the result directly.

For other functions, `abs` overflow check is skipped since the overflow will eventually be caught by the bit sum check.

We also considered the following:
- Check that the MSB of the absolute value is not negative (which would be if value is `i128::MIN`). However this is computationally expensive as well.